### PR TITLE
Move cloud-sql-proxy to / and adjust tagging policy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 All notable changes to this project will be documented in this file.
 
 ## [v1.17.0+mintel.0.2.0]
-
 ### Changed
 - Save `cloud_sql_proxy` to `/cloud_sql_proxy` (as per upstream)
 - Tag using upstream version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [v1.17.0+mintel.0.2.0]
+
+### Changed
+- Save `cloud_sql_proxy` to `/cloud_sql_proxy` (as per upstream)
+- Tag using upstream version
+
 ## [v0.1.0]
 ### Added
 - Initial release

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM busybox:1.31.1-glibc
 ARG BUILD_DATE
 ARG VCS_REF
 
-COPY --from=gcr.io/cloudsql-docker/gce-proxy:1.17 /cloud_sql_proxy /usr/local/bin/
+COPY --from=gcr.io/cloudsql-docker/gce-proxy:1.17 /cloud_sql_proxy /
 COPY --from=banzaicloud/vault-env:1.3.2 /usr/local/bin/vault-env /usr/local/bin/
 COPY --from=gcr.io/distroless/base-debian10:nonroot /etc/ssl /etc/ssl
 


### PR DESCRIPTION
- `/cloud_sql_proxy` is where the upstream binary is deployed to, so we will do the same
- Adjusted tagging policy to mimic upstream, plus add our mintel-build info (`v1.17.0+mintel.0.2.0`)